### PR TITLE
Update bash_uint.bash

### DIFF
--- a/bash_uint.bash
+++ b/bash_uint.bash
@@ -7,31 +7,39 @@ dec2uint () (
     ## convert (compress) ascii text integers into uint representation integers
     # values may be passed via the cmdline or via stdin
     # immediately before each value printed as a uint, there will be a 1 byte hexadecimal pair:
-    #   1st hex: tells how many (0-15) NULL-delimited reads are needed to read the [start of] the following number
-    #   2nd hex: tells how many (0-15) additional bytes must be read (after the last NULL-delimited read) to read the [end of] the following number
+    #    1st hex (first 4 bits): tells how many (0-15/f) NULL-delimited reads are needed to read the [start of] the following number
+    #    2nd hex (last 4 bits):  tells how many (0-15/f) additional bytes must be read (after the last NULL-delimited read) to read the [end of] the following number
+    # after the last value a NULL we be printed (unless -n flag is set)
+    # flags: if the 1st command-line input is '-n' then the final trailing NULL will be omitted
     
     local -a A;
-    local a a0 a1 a2 b nn;    
+    local a a0 a1 a2 b nn noTrailingNullFlag;    
+
+    if [[ "${1}" == '-n' ]] ; then
+        noTrailingNullFlag=true;
+        shift 1;
+    else
+        noTrailingNullFlag=false;
+    fi
     
     for nn in "${@}"; do
         printf -v a '%x' "$nn";
         (( ( ${#a} & 1 ) == 0 )) || a="0${a}";
-        a="${a//@([0-9a-f])@([0-9a-f])/& }"
-        a1=${a//@(@([1-9a-f])@([0-9a-f])||@([0-9a-f])@([1-9a-f])||@( ))/}
-        a2=${a##*00}
-        a2=${a2// /}
-        printf -v a0 '%x' $(( ${#a1} / 2 )) $(( ${#a2} / 2 ))
-        printf -v b '\\x%s' "${a0}" ${a//@([0-9a-f])@([0-9a-f])/& };
+        a="${a//@([0-9a-f])@([0-9a-f])/& }";
+        a1="${a//@([1-9a-f][0-9a-f]||[0-9a-f][1-9a-f]|| )/}";
+        a2="${a//@(*00|| )/}";
+        printf -v a0 '%x' "$(( ${#a1} >> 1 ))" "$(( ${#a2} >> 1 ))";
+        printf -v b '\\x%s' "${a0}" ${a};
         printf "$b";
     done
     
     [[ "${FUNCNAME[0]}" == "${FUNCNAME[1]}" ]] ||  {
         [ -t 0 ] || {
-            mapfile -t -u ${fd0} A;
-            dec2uint "${A[@]}"
+            mapfile -t A <(cat <&${fd0});
+            dec2uint -n "${A[@]}";
         } {fd0}<&0    
     
-        printf '\0'
+        ${noTrailingNullFlag} || printf '\0';
     }
 
 )
@@ -39,35 +47,36 @@ dec2uint () (
 uint2dec() (
     ## convert (expand) uint representation integers into ascii text integers
     # values may be passed via stdin only (passing on cmdline would drop NULL bytes)
-    # NOTE: expects each value to have a 1-byte hexidecimal pair (described in dec2uint) immediately before each number 
+    # NOTE: uint2dec expects each value to have a 1-byte hexidecimal pair (as described in dec2uint) immediately before each number:
+    #    1st hex (first 4 bits): tells how many (0-15/f) NULL-delimited reads are needed to read the [start of] the following number
+    #    2nd hex (last 4 bits):  tells how many (0-15/f) additional bytes must be read (after the last NULL-delimited read) to read the [end of] the following number
     
-    local -a A
+    local -a A;
     local a b n n0 n1;
+    
     {
         while true; do
-            read -r -N 1 -u ${fd0}
+            read -r -N 1 -u ${fd0};
             
-            [[ $REPLY ]] || break
+            [[ $REPLY ]] || break;
             
-            printf -v n '%d' \'"${REPLY}"
+            printf -v n '%d' \'"${REPLY}";
             
-            n0=$(( ( $n & 240 ) >> 4 ))
-            n1=$(( $n & 15 ))
+            n0=$(( ( $n & 240 ) >> 4 ));
+            n1=$(( $n & 15 ));
             
             if [[ "$n0" == 0 ]]; then
-                A=()
+                A=();
             else
                 mapfile -t -n ${n0} -d '' -u ${fd0} A
                 A=("${A[@]//?/\'& }");
-                A=(${A[@]/%/' 0x00 '})
+                A=(${A[@]/%/' 0x00 '});
             fi
             
-            if [[ "$n1" == 0 ]]; then
-                a=''
-            else
-                read -r -N ${n1} -u ${fd0} a
+            [[ "$n1" == 0 ]] || {
+                read -r -N ${n1} -u ${fd0} a;
                 A+=(${a//?/\'& });
-            fi        
+            }
         
             printf -v b '%02x' "${A[@]}";
             printf '%i ' $(( 16#"${b}" ));


### PR DESCRIPTION
test

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the `dec2uint` function by adding support for an optional '-n' flag to omit the final trailing NULL. It also improves the readability and maintainability of both `dec2uint` and `uint2dec` functions through refined variable names and additional comments.

- **Enhancements**:
    - Enhanced the `dec2uint` function to support an optional '-n' flag that omits the final trailing NULL.
    - Improved the readability and maintainability of the `dec2uint` and `uint2dec` functions by refining variable names and adding comments.

<!-- Generated by sourcery-ai[bot]: end summary -->